### PR TITLE
fix: wrap unique_id with str() to satisfy HA string requirement

### DIFF
--- a/custom_components/duosida/config_flow.py
+++ b/custom_components/duosida/config_flow.py
@@ -97,7 +97,7 @@ class DuosidaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_create_or_update_entry(self, cloud_device):
         """Create or update config entry"""
         existing_entry = await self.async_set_unique_id(
-            cloud_device[DeviceAttribute.ID], raise_on_progress=False
+            str(cloud_device[DeviceAttribute.ID]), raise_on_progress=False
         )
         if existing_entry:
             data = existing_entry.data.copy()


### PR DESCRIPTION
## Description
Fixes #18

`DeviceAttribute.ID` returns an `int` from the API, but Home Assistant requires `unique_id` to be a `str`. This causes the following error on every startup:

Config entry 'Cargy' from integration duosida has an invalid unique_id '1573' of type int when a string is expected
## Fix
Wrapped `cloud_device[DeviceAttribute.ID]` with `str()` in `async_create_or_update_entry`.
